### PR TITLE
NEO-2221 Update autocomplete configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Required Android permissions in manifest:
 
 ```
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.example.search_completion">
+    package="com.yourparkingspace.search_completion">
     <uses-permission android:name="android.permission.INTERNET"/>
 </manifest>
 

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,5 +1,5 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.example.search_completion">
+    package="com.yourparkingspace.search_completion">
     
     <!-- Required permissions for Google Places API -->
     <uses-permission android:name="android.permission.INTERNET"/>

--- a/android/src/main/kotlin/com/yourparkingspace/search_completion/SearchCompletionPlugin.kt
+++ b/android/src/main/kotlin/com/yourparkingspace/search_completion/SearchCompletionPlugin.kt
@@ -18,6 +18,7 @@ class SearchCompletionPlugin: FlutterPlugin, MethodChannel.MethodCallHandler {
     private lateinit var context: Context
     private lateinit var placesClient: PlacesClient
     private var eventSink: EventChannel.EventSink? = null
+    private lateinit var autocompleteSessionToken : AutoCompleteSessionToken
 
     override fun onAttachedToEngine(binding: FlutterPlugin.FlutterPluginBinding) {
         context = binding.applicationContext
@@ -43,6 +44,7 @@ class SearchCompletionPlugin: FlutterPlugin, MethodChannel.MethodCallHandler {
                 if (apiKey != null) {
                     Places.initialize(context, apiKey)
                     placesClient = Places.createClient(context)
+                    autocompleteSessionToken = AutocompleteSessionToken.newInstance()
                     result.success(null)
                 } else {
                     result.error("MISSING_API_KEY", "Google Places API key is required", null)
@@ -67,6 +69,8 @@ class SearchCompletionPlugin: FlutterPlugin, MethodChannel.MethodCallHandler {
 
     private fun performSearch(query: String) {
         val request = FindAutocompletePredictionsRequest.builder()
+            .setCountries(listOf("uk", "ie"))
+            .setSessionToken(autocompleteSessionToken)
             .setQuery(query)
             .build()
 
@@ -87,9 +91,10 @@ class SearchCompletionPlugin: FlutterPlugin, MethodChannel.MethodCallHandler {
     }
 
     private fun getPlaceDetails(placeId: String, result: MethodChannel.Result) {
-        val placeFields = listOf(Place.Field.LAT_LNG)
+        val placeFields = listOf(Place.Field.LAT_LNG, Place.Field.NAME, Place.Field.ADDRESS)
         val request = com.google.android.libraries.places.api.net.FetchPlaceRequest
             .builder(placeId, placeFields)
+            .setSessionToken(autocompleteSessionToken)
             .build()
 
         placesClient.fetchPlace(request)

--- a/android/src/main/kotlin/com/yourparkingspace/search_completion/SearchCompletionPlugin.kt
+++ b/android/src/main/kotlin/com/yourparkingspace/search_completion/SearchCompletionPlugin.kt
@@ -44,6 +44,11 @@ class SearchCompletionPlugin: FlutterPlugin, MethodChannel.MethodCallHandler {
                 if (apiKey != null) {
                     Places.initialize(context, apiKey)
                     placesClient = Places.createClient(context)
+
+                    // Note: Ensure a new session token is obtained by the search_completion plugin for
+                    // Google Places API cost efficiency, else we would get charged for each
+                    // autocomplete request (every time the search term updates) and then once again
+                    // when we fetch place details, instead of just once for the combined session
                     autocompleteSessionToken = AutocompleteSessionToken.newInstance()
                     result.success(null)
                 } else {
@@ -57,7 +62,7 @@ class SearchCompletionPlugin: FlutterPlugin, MethodChannel.MethodCallHandler {
                     result.success(null)
                 }
             }
-            "getCoordinates" -> {
+            "getPlaceData" -> {
                 val placeId = call.argument<String>("placeId")
                 if (placeId != null) {
                     getPlaceDetails(placeId, result)
@@ -103,6 +108,8 @@ class SearchCompletionPlugin: FlutterPlugin, MethodChannel.MethodCallHandler {
                 val latLng = place.latLng
                 if (latLng != null) {
                     result.success(mapOf(
+                        "name" to place.name,
+                        "address" to place.address,
                         "latitude" to latLng.latitude,
                         "longitude" to latLng.longitude
                     ))

--- a/android/src/main/kotlin/com/yourparkingspace/search_completion/SearchCompletionPlugin.kt
+++ b/android/src/main/kotlin/com/yourparkingspace/search_completion/SearchCompletionPlugin.kt
@@ -65,8 +65,9 @@ class SearchCompletionPlugin: FlutterPlugin, MethodChannel.MethodCallHandler {
             }
             "getPlaceData" -> {
                 val placeId = call.argument<String>("placeId")
+                val placeName = "${call.argument<String>("title")}, ${call.argument<String>("subtitle")}"
                 if (placeId != null) {
-                    getPlaceDetails(placeId, result)
+                    getPlaceDetails(placeId, placeName, result)
                 }
             }
             else -> result.notImplemented()
@@ -96,8 +97,12 @@ class SearchCompletionPlugin: FlutterPlugin, MethodChannel.MethodCallHandler {
             }
     }
 
-    private fun getPlaceDetails(placeId: String, result: MethodChannel.Result) {
-        val placeFields = listOf(Place.Field.LAT_LNG, Place.Field.NAME, Place.Field.ADDRESS)
+    private fun getPlaceDetails(
+        placeId: String,
+        placeName: String,
+        result: MethodChannel.Result
+    ) {
+        val placeFields = listOf(Place.Field.LAT_LNG)
         val request = com.google.android.libraries.places.api.net.FetchPlaceRequest
             .builder(placeId, placeFields)
             .setSessionToken(autocompleteSessionToken)
@@ -109,8 +114,7 @@ class SearchCompletionPlugin: FlutterPlugin, MethodChannel.MethodCallHandler {
                 val latLng = place.latLng
                 if (latLng != null) {
                     result.success(mapOf(
-                        "name" to place.name,
-                        "address" to place.address,
+                        "name" to placeName,
                         "latitude" to latLng.latitude,
                         "longitude" to latLng.longitude
                     ))

--- a/android/src/main/kotlin/com/yourparkingspace/search_completion/SearchCompletionPlugin.kt
+++ b/android/src/main/kotlin/com/yourparkingspace/search_completion/SearchCompletionPlugin.kt
@@ -46,10 +46,13 @@ class SearchCompletionPlugin: FlutterPlugin, MethodChannel.MethodCallHandler {
                     Places.initialize(context, apiKey)
                     placesClient = Places.createClient(context)
 
-                    // Note: Ensure a new session token is obtained by the search_completion plugin for
-                    // Google Places API cost efficiency, else we would get charged for each
-                    // autocomplete request (every time the search term updates) and then once again
-                    // when we fetch place details, instead of just once for the combined session
+                    // Note: Google Places API is billed per session. Ensure a new session token is
+                    // obtained by the search_completion plugin when the search is initialises
+                    // (e.g. when the search screen opens) for cost efficiency,
+                    // If session token is not included each autocomplete request (on every
+                    // search term update) will count as new session and then another new session
+                    // when we fetch place details, resulting in several sessions instead of
+                    // just one combined session for a place search.
                     autocompleteSessionToken = AutocompleteSessionToken.newInstance()
                     result.success(null)
                 } else {

--- a/android/src/main/kotlin/com/yourparkingspace/search_completion/SearchCompletionPlugin.kt
+++ b/android/src/main/kotlin/com/yourparkingspace/search_completion/SearchCompletionPlugin.kt
@@ -3,6 +3,7 @@ package com.yourparkingspace.search_completion
 import android.content.Context
 import com.google.android.libraries.places.api.Places
 import com.google.android.libraries.places.api.model.AutocompletePrediction
+import com.google.android.libraries.places.api.model.AutocompleteSessionToken
 import com.google.android.libraries.places.api.model.Place
 import com.google.android.libraries.places.api.net.FindAutocompletePredictionsRequest
 import com.google.android.libraries.places.api.net.PlacesClient
@@ -18,7 +19,7 @@ class SearchCompletionPlugin: FlutterPlugin, MethodChannel.MethodCallHandler {
     private lateinit var context: Context
     private lateinit var placesClient: PlacesClient
     private var eventSink: EventChannel.EventSink? = null
-    private lateinit var autocompleteSessionToken : AutoCompleteSessionToken
+    private lateinit var autocompleteSessionToken : AutocompleteSessionToken
 
     override fun onAttachedToEngine(binding: FlutterPlugin.FlutterPluginBinding) {
         context = binding.applicationContext

--- a/ios/Classes/SearchCompletionPlugin.swift
+++ b/ios/Classes/SearchCompletionPlugin.swift
@@ -38,7 +38,7 @@ public class SearchCompletionPlugin: NSObject, FlutterPlugin {
                 searchManager?.searchTerm = searchTerm
                 result(nil)
             }
-        case "getCoordinates":
+        case "getPlaceData":
             if let args = call.arguments as? [String: Any],
               let title: String = args["title"] as? String,
               let subtitle: String = args["subtitle"] as? String,
@@ -49,6 +49,8 @@ public class SearchCompletionPlugin: NSObject, FlutterPlugin {
                       subtitle: subtitle
                     )
                     result([
+                        "name": title,
+                        "address": subtitle,
                         "latitude": coordinates?.latitude as? Double,
                         "longitude": coordinates?.longitude as? Double
                     ])

--- a/ios/Classes/SearchCompletionPlugin.swift
+++ b/ios/Classes/SearchCompletionPlugin.swift
@@ -49,8 +49,7 @@ public class SearchCompletionPlugin: NSObject, FlutterPlugin {
                       subtitle: subtitle
                     )
                     result([
-                        "name": title,
-                        "address": subtitle,
+                        "name": "\(title), \(subtitle)",
                         "latitude": coordinates?.latitude as? Double,
                         "longitude": coordinates?.longitude as? Double
                     ])


### PR DESCRIPTION
This PR makes a few configuration changes below.
- Returns place name along with the co-ordinates for both platforms
- Restricts autocomplete search on Android to return results only from UK and Ireland
- Ensure all search activity while on the search screen counts as a single session for Google Places API billing.