### PR TITLE
NEO-2301: [SC] add region selection to iOS search completion

### DIFF
--- a/ios/Classes/MapKitRegionUtility.swift
+++ b/ios/Classes/MapKitRegionUtility.swift
@@ -79,13 +79,13 @@ struct MapKitRegionUtility {
 // MARK: - MKCoordinateRegion Extension
 extension MKCoordinateRegion {
     init?(coordinates: [CLLocationCoordinate2D]) {
-        let primeRegion = MKCoordinateRegion.region(
+        let primeRegion = MKCoordinateRegion.mapKitRegion(
             for: coordinates,
             transform: { $0 },
             inverseTransform: { $0 }
         )
         
-        let transformedRegion = MKCoordinateRegion.region(
+        let transformedRegion = MKCoordinateRegion.mapKitRegion(
             for: coordinates,
             transform: Self.transform,
             inverseTransform: Self.inverseTransform

--- a/ios/Classes/MapKitRegionUtility.swift
+++ b/ios/Classes/MapKitRegionUtility.swift
@@ -1,0 +1,149 @@
+import UIKit
+import MapKit
+
+// MARK: - BoundingBox
+struct MapKitBoundingBox {
+    let min: CLLocationCoordinate2D
+    let max: CLLocationCoordinate2D
+    
+    init(mapRect: MKMapRect) {
+        let bottomLeft = MKMapPoint(x: mapRect.origin.x, y: mapRect.origin.y)
+        let topRight = MKMapPoint(x: mapRect.maxX, y: mapRect.maxY)
+        
+        self.min = bottomLeft.coordinate
+        self.max = topRight.coordinate
+    }
+    
+    init(displayRegion: MapKitGeographicRegion) {
+        let coordinates = displayRegion.coordinates
+        self.min = coordinates.min
+        self.max = coordinates.max
+    }
+}
+
+// MARK: - GeographicRegion
+enum MapKitGeographicRegion: String {
+    case asia = "25.5886467,-12.2118513,-168.97788,81.9661865"
+    case africa = "-25.383911,-47.1313489,63.8085939,37.5359"
+    case northAmerica = "-172.66113495,5.4961,-15.51269745,83.6655766261"
+    case southAmerica = "-110.0281,-56.1455,-28.650543,17.6606999"
+    case antarctica = "-180.0,-85.0511287798,180.0,-60.1086999"
+    case europe = "-25.48824365,32.5960451596,74.3555001,73.1927977675"
+    case australia = "110.9510339,-54.8337658,159.2872223,-9.1870264"
+    case ukAndIreland = "-16.6649026112,47.7502953806,4.3354981542,60.9916781275"
+
+    var mapKitRegionCode: String {
+        switch self {
+            case .asia: return "AS"
+            case .africa: return "AF"
+            case .northAmerica: return "NA"
+            case .southAmerica: return "SA"
+            case .antarctica: return "AQ"
+            case .europe: return "EU"
+            case .australia: return "AU"
+            case .ukAndIreland: return "UKIE"
+        }
+    }
+    
+    static func from(mapKitRegionCode: String) -> MapKitGeographicRegion? {
+        switch mapKitRegionCode.uppercased() {
+            case "AS": return .asia
+            case "AF": return .africa
+            case "NA": return .northAmerica
+            case "SA": return .southAmerica
+            case "AQ": return .antarctica
+            case "EU": return .europe
+            case "AU": return .australia
+            case "UKIE": return .ukAndIreland
+            default: return nil
+        }
+    }
+    
+    var coordinates: (min: CLLocationCoordinate2D, max: CLLocationCoordinate2D) {
+        let values = rawValue.components(separatedBy: ",").compactMap { Double($0) }
+        return (
+            min: CLLocationCoordinate2D(latitude: values[3], longitude: values[2]),
+            max: CLLocationCoordinate2D(latitude: values[1], longitude: values[0])
+        )
+    }
+}
+
+// MARK: - RegionUtility
+struct MapKitRegionUtility {
+    func region(for region: MapKitGeographicRegion) -> MKCoordinateRegion? {
+        let coordinates = region.coordinates
+        return MKCoordinateRegion(coordinates: [coordinates.min, coordinates.max])
+    }
+}
+
+// MARK: - MKCoordinateRegion Extension
+extension MKCoordinateRegion {
+    init?(coordinates: [CLLocationCoordinate2D]) {
+        let primeRegion = MKCoordinateRegion.region(
+            for: coordinates,
+            transform: { $0 },
+            inverseTransform: { $0 }
+        )
+        
+        let transformedRegion = MKCoordinateRegion.region(
+            for: coordinates,
+            transform: Self.transform,
+            inverseTransform: Self.inverseTransform
+        )
+        
+        if let a = primeRegion,
+        let b = transformedRegion,
+        let min = [a, b].min(by: { $0.span.longitudeDelta < $1.span.longitudeDelta }) {
+            self = min
+        } else if let region = primeRegion ?? transformedRegion {
+            self = region
+        } else {
+            return nil
+        }
+    }
+    
+    private static func transform(c: CLLocationCoordinate2D) -> CLLocationCoordinate2D {
+        c.longitude < 0 ? CLLocationCoordinate2DMake(c.latitude, 360 + c.longitude) : c
+    }
+    
+    private static func inverseTransform(c: CLLocationCoordinate2D) -> CLLocationCoordinate2D {
+        c.longitude > 180 ? CLLocationCoordinate2DMake(c.latitude, -360 + c.longitude) : c
+    }
+    
+    private static func mapKitRegion(
+        for coordinates: [CLLocationCoordinate2D],
+        transform: (CLLocationCoordinate2D) -> CLLocationCoordinate2D,
+        inverseTransform: (CLLocationCoordinate2D) -> CLLocationCoordinate2D
+    ) -> MKCoordinateRegion? {
+        guard !coordinates.isEmpty else { return nil }
+        
+        if coordinates.count == 1 {
+            return MKCoordinateRegion(
+                center: coordinates[0],
+                span: MKCoordinateSpan(latitudeDelta: 1, longitudeDelta: 1)
+            )
+        }
+        
+        let transformed = coordinates.map(transform)
+        
+        guard let minLat = transformed.min(by: { $0.latitude < $1.latitude })?.latitude,
+            let maxLat = transformed.max(by: { $0.latitude < $1.latitude })?.latitude,
+            let minLon = transformed.min(by: { $0.longitude < $1.longitude })?.longitude,
+            let maxLon = transformed.max(by: { $0.longitude < $1.longitude })?.longitude
+        else { return nil }
+        
+        let span = MKCoordinateSpan(
+            latitudeDelta: maxLat - minLat,
+            longitudeDelta: maxLon - minLon
+        )
+        
+        let center = inverseTransform(
+            CLLocationCoordinate2DMake(
+                maxLat - span.latitudeDelta / 2,
+                maxLon - span.longitudeDelta / 2
+            )
+        )
+        
+        return MKCoordinateRegion(center: center, span: span)
+    }
+}

--- a/ios/Classes/MapKitSearchCompletionManager.swift
+++ b/ios/Classes/MapKitSearchCompletionManager.swift
@@ -1,5 +1,5 @@
 import Combine
-import Flutter
+import os.log
 import MapKit
 
 protocol SearchCompletionManagerProtocol {
@@ -41,7 +41,7 @@ final class MapKitSearchCompletionManager: NSObject, SearchCompletionManagerProt
         super.init()
         
         self.searchCompleter.delegate = self
-        FlutterLog.info("Search completion manager initialized with region code: \(String(describing: region))")
+        os_log("Search completion manager initialized with region code: %@", log: .default, type: .debug, String(describing: region))
     }
     
     func returnCoordinatesFromSearchResult(title: String?, subtitle: String?) async -> CLLocationCoordinate2D?  {

--- a/ios/Classes/MapKitSearchCompletionManager.swift
+++ b/ios/Classes/MapKitSearchCompletionManager.swift
@@ -40,6 +40,7 @@ final class MapKitSearchCompletionManager: NSObject, SearchCompletionManagerProt
         super.init()
         
         self.searchCompleter.delegate = self
+        print("Search completion manager initialized with region code: \(String(describing: region))") 
     }
     
     func returnCoordinatesFromSearchResult(title: String?, subtitle: String?) async -> CLLocationCoordinate2D?  {

--- a/ios/Classes/MapKitSearchCompletionManager.swift
+++ b/ios/Classes/MapKitSearchCompletionManager.swift
@@ -2,7 +2,6 @@ import Combine
 import MapKit
 
 protocol SearchCompletionManagerProtocol {
-    var region: MKCoordinateRegion? { get set }
     var searchTerm: String { get set }
     var autoCompletePublisher: AnyPublisher<[any AutoCompletedSearchResult], Never> { get }
     func returnCoordinatesFromSearchResult(title: String?, subtitle: String?) async -> CLLocationCoordinate2D? 
@@ -17,7 +16,7 @@ protocol AutoCompletedSearchResult: Hashable {
 final class MapKitSearchCompletionManager: NSObject, SearchCompletionManagerProtocol {
     
     var autoCompletePublisher: AnyPublisher<[any AutoCompletedSearchResult], Never>
-    var region: MKCoordinateRegion?
+    
     var searchTerm: String {
         didSet {
             searchCompleter.queryFragment = searchTerm
@@ -27,6 +26,7 @@ final class MapKitSearchCompletionManager: NSObject, SearchCompletionManagerProt
     private let searchCompleter: MKLocalSearchCompleter
     private let autoCompleteSubject = PassthroughSubject<[any AutoCompletedSearchResult], Never>()
     private var autoCompleteResults: [MKLocalSearchCompletion] = []
+    private var region: MKCoordinateRegion?
 
     init(
         region: MKCoordinateRegion? = nil,

--- a/ios/Classes/MapKitSearchCompletionManager.swift
+++ b/ios/Classes/MapKitSearchCompletionManager.swift
@@ -41,7 +41,7 @@ final class MapKitSearchCompletionManager: NSObject, SearchCompletionManagerProt
         super.init()
         
         self.searchCompleter.delegate = self
-        os_log("Search completion manager initialized with region code: %@", log: .default, type: .debug, String(describing: region))
+        os_log("Search completion manager initialized with region: %@", log: .default, type: .debug, String(describing: region))
     }
     
     func returnCoordinatesFromSearchResult(title: String?, subtitle: String?) async -> CLLocationCoordinate2D?  {

--- a/ios/Classes/MapKitSearchCompletionManager.swift
+++ b/ios/Classes/MapKitSearchCompletionManager.swift
@@ -1,4 +1,5 @@
 import Combine
+import Flutter
 import MapKit
 
 protocol SearchCompletionManagerProtocol {
@@ -40,7 +41,7 @@ final class MapKitSearchCompletionManager: NSObject, SearchCompletionManagerProt
         super.init()
         
         self.searchCompleter.delegate = self
-        print("Search completion manager initialized with region code: \(String(describing: region))") 
+        FlutterLog.info("Search completion manager initialized with region code: \(String(describing: region))")
     }
     
     func returnCoordinatesFromSearchResult(title: String?, subtitle: String?) async -> CLLocationCoordinate2D?  {

--- a/ios/Classes/SearchCompletionPlugin.swift
+++ b/ios/Classes/SearchCompletionPlugin.swift
@@ -63,8 +63,7 @@ public class SearchCompletionPlugin: NSObject, FlutterPlugin {
     }
     
     private func initializeSearchManager(searchRegion: String? = nil) {
-        searchManager = MapKitSearchCompletionManager()
-        searchManager?.region = MapKitGeographicRegion.searchRegion(from: searchRegion)
+        searchManager = MapKitSearchCompletionManager(region: MapKitGeographicRegion.searchRegion(from: searchRegion))
         searchManager?.autoCompletePublisher
             .sink { [weak self] completions in
                 let results = completions.map { completion in

--- a/ios/Classes/SearchCompletionPlugin.swift
+++ b/ios/Classes/SearchCompletionPlugin.swift
@@ -31,8 +31,8 @@ public class SearchCompletionPlugin: NSObject, FlutterPlugin {
         switch call.method {
         case "initialize":
             let args = call.arguments as? [String: Any]
-            let searchRegion = args?["mapKitSearchRegionCode"] as? String?
-            initializeSearchManager(searchRegion: searchRegion)
+            let searchRegion = args?["mapKitSearchRegionCode"] as? String
+            initializeSearchManager(searchRegion: searchRegion ?? "")
             result(nil)
         case "updateSearchTerm":
             if let args = call.arguments as? [String: Any],
@@ -62,8 +62,9 @@ public class SearchCompletionPlugin: NSObject, FlutterPlugin {
         }
     }
     
-    private func initializeSearchManager(searchRegion: String? = nil) {
-        searchManager = MapKitSearchCompletionManager(region: MapKitGeographicRegion.searchRegion(from: searchRegion))
+    private func initializeSearchManager(searchRegion: String) {
+        searchManager = MapKitSearchCompletionManager(region: MapKitRegionUtility()
+            .region(for: MapKitGeographicRegion.from(mapKitRegionCode: searchRegion) ?? .ukAndIreland))
         searchManager?.autoCompletePublisher
             .sink { [weak self] completions in
                 let results = completions.map { completion in

--- a/ios/Classes/SearchCompletionPlugin.swift
+++ b/ios/Classes/SearchCompletionPlugin.swift
@@ -12,16 +12,16 @@ public class SearchCompletionPlugin: NSObject, FlutterPlugin {
 
     public static func register(with registrar: FlutterPluginRegistrar) {
         let channel = FlutterMethodChannel(
-          name: "search_completion",
-          binaryMessenger: registrar.messenger()
+            name: "search_completion",
+            binaryMessenger: registrar.messenger()
         )
         let instance = SearchCompletionPlugin()
         instance.registrar = registrar
         registrar.addMethodCallDelegate(instance, channel: channel)
 
         let eventChannel = FlutterEventChannel(
-          name: "search_completion_events",
-          binaryMessenger: registrar.messenger()
+            name: "search_completion_events",
+            binaryMessenger: registrar.messenger()
         )
     
         eventChannel.setStreamHandler(instance)
@@ -30,23 +30,25 @@ public class SearchCompletionPlugin: NSObject, FlutterPlugin {
     public func handle(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
         switch call.method {
         case "initialize":
-            initializeSearchManager()
+            let args = call.arguments as? [String: Any]
+            let searchRegion = args?["mapKitSearchRegionCode"] as? String?
+            initializeSearchManager(searchRegion: searchRegion)
             result(nil)
         case "updateSearchTerm":
             if let args = call.arguments as? [String: Any],
-              let searchTerm = args["searchTerm"] as? String {
+            let searchTerm = args["searchTerm"] as? String {
                 searchManager?.searchTerm = searchTerm
                 result(nil)
             }
         case "getPlaceData":
             if let args = call.arguments as? [String: Any],
-              let title: String = args["title"] as? String,
-              let subtitle: String = args["subtitle"] as? String,
-              let searchManager {
+                let title: String = args["title"] as? String,
+                let subtitle: String = args["subtitle"] as? String,
+                let searchManager {
                 Task {
                     let coordinates: CLLocationCoordinate2D? = await searchManager.returnCoordinatesFromSearchResult(
-                      title: title, 
-                      subtitle: subtitle
+                        title: title, 
+                        subtitle: subtitle
                     )
                     result([
                         "name": "\(title), \(subtitle)",
@@ -60,8 +62,9 @@ public class SearchCompletionPlugin: NSObject, FlutterPlugin {
         }
     }
     
-    private func initializeSearchManager() {
+    private func initializeSearchManager(searchRegion: String? = nil) {
         searchManager = MapKitSearchCompletionManager()
+        searchManager?.region = MapKitGeographicRegion.searchRegion(from: searchRegion)
         searchManager?.autoCompletePublisher
             .sink { [weak self] completions in
                 let results = completions.map { completion in
@@ -77,7 +80,7 @@ public class SearchCompletionPlugin: NSObject, FlutterPlugin {
     }
     
     private func sendSearchResults(_ results: [[String: Any]]) {
-      eventSink?(results)
+        eventSink?(results)
     }
 }
 

--- a/ios/search_completion.podspec
+++ b/ios/search_completion.podspec
@@ -4,7 +4,7 @@
 #
 Pod::Spec.new do |s|
   s.name             = 'search_completion'
-  s.version          = '0.0.1'
+  s.version          = '1.0.0'
   s.summary          = 'A new Flutter plugin project.'
   s.description      = <<-DESC
 A new Flutter plugin project.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: search_completion
 description: A Flutter plugin for iOS MapKit search completion
-version: 0.0.1
+version: 1.0.0
 platforms:
   ios:
   android:


### PR DESCRIPTION
https://your-parking-space.atlassian.net/browse/NEO-2301

Requirements:

At initialisation, allow the iOS search completion tool to accept a region code to fine-tune the results returned

```
var mapKitRegionCode: String {
        switch self {
            case .asia: return "AS"
            case .africa: return "AF"
            case .northAmerica: return "NA"
            case .southAmerica: return "SA"
            case .antarctica: return "AQ"
            case .europe: return "EU"
            case .australia: return "AU"
            case .ukAndIreland: return "UKIE"
        }
    }

```
The code is passed at initialisation along with the Google Places API Key in default_search_completion_datasource:

```
  Future<void> initialize({String? androidApiKey, String? mapKitSearchRegionCode}) async {
    if (Platform.isAndroid) {
      if (androidApiKey == null) {
        throw Exception('Android API key is required for Google Places');
      }
      await _channel.invokeMethod('initialize', {'apiKey': androidApiKey});
    } else {
      await _channel.invokeMethod('initialize', {'mapKitSearchRegionCode': mapKitSearchRegionCode});
    }
  }
```

